### PR TITLE
Fix the keyError issue

### DIFF
--- a/report_artifacts_tagvalue.py
+++ b/report_artifacts_tagvalue.py
@@ -150,11 +150,11 @@ def generate_tagvalue_report(reportData):
                                 
             report_ptr.write("LicenseConcluded: %s\n" %file["licenseConcluded"])
 
-            if len(file["copyrightText"]) > 0:
+            if len(file.get("copyrightText", "")) > 0:
                 report_ptr.write("FileCopyrightText: <text>%s</text>\n" %file["copyrightText"])
                 
 
-            for license in file["licenseInfoInFiles"]:
+            for license in file.get("licenseInfoInFiles", []):
                 report_ptr.write("LicenseInfoInFile: %s\n" %license)
 
             report_ptr.write("\n")

--- a/report_data.py
+++ b/report_data.py
@@ -269,7 +269,7 @@ def gather_data_for_report(baseURL, projectID, authToken, reportData):
                     relationships.append(fileRelationship)
 
                     # Surfaces the file level evidence to the assocaited package
-                    licenseInfoFromFiles = licenseInfoFromFiles + fileDetail["licenseInfoInFiles"]
+                    licenseInfoFromFiles = licenseInfoFromFiles + fileDetail.get("licenseInfoInFiles", [])
     
                 # Create a hash of the file hashes for PackageVerificationCode 
                 try:
@@ -506,7 +506,7 @@ def manage_unassociated_files(filesNotInInventory, filePathtoID, rootSPDXID, cre
         fileHashes.append(filePathtoID[fileName]["fileSHA1"])
 
         # Surfaces the file level evidence to the assocaited package
-        licenseInfoFromFiles = licenseInfoFromFiles + fileDetails["licenseInfoInFiles"]
+        licenseInfoFromFiles = licenseInfoFromFiles + fileDetails.get("licenseInfoInFiles", [])
   
        # Define the relationship of the file to the package
         fileRelationship = {}


### PR DESCRIPTION
Fix issue https://github.com/flexera-public/sca-codeinsight-reports-spdx/issues/11

+ use the `dict.get` to handle keyError for licenseInfoInFiles